### PR TITLE
Add support for mongodb driver v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Build Status](https://app.travis-ci.com/mhassan1/mongodb-queue-up.svg?branch=main)](https://app.travis-ci.com/github/mhassan1/mongodb-queue-up) [![NPM](https://nodei.co/npm/mongodb-queue-up.png?mini=true)](https://nodei.co/npm/mongodb-queue-up/)
 
-This is a fork of [mongodb-queue@4](https://www.npmjs.com/package/mongodb-queue/v/4.0.0) that adds support for MongoDB Driver v4 and v5.
+This is a fork of [mongodb-queue@4](https://www.npmjs.com/package/mongodb-queue/v/4.0.0) that adds support for MongoDB Driver v4, v5, and v6.
 
 A really light-weight way to create queues with a nice API if you're already
 using MongoDB.
 
-Now compatible with the MongoDB v4 and v5 drivers.
+Now compatible with the MongoDB v4, v5, and v6 drivers.
 
 For MongoDB v3 driver use [mongodb-queue@4](https://www.npmjs.com/package/mongodb-queue/v/4.0.0).
 
@@ -433,6 +433,10 @@ We may add the ability for each function to return a promise in the future so it
 async/await.
 
 ## Releases ##
+
+### 5.2.0 (2023-09-11) ###
+
+* [NEW] Added support for mongodb driver v6
 
 ### 5.1.0 (2023-08-04) ###
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -139,7 +139,7 @@ Queue.prototype.get = function(opts, callback) {
         }
     }
 
-    self._ops.findOneAndUpdate3(query, update, { sort: sort, returnDocument : 'after' }, function(err, result) {
+    self._ops.findOneAndUpdate3(query, update, { sort: sort, returnDocument : 'after', includeResultMetadata: true }, function(err, result) {
         if (err) return callback(err)
         var msg = result.value
         if (!msg) return callback()
@@ -193,7 +193,7 @@ Queue.prototype.ping = function(ack, opts, callback) {
             visible : nowPlusSecs(visibility)
         }
     }
-    self._ops.findOneAndUpdate3(query, update, { returnDocument : 'after' }, function(err, msg, blah) {
+    self._ops.findOneAndUpdate3(query, update, { returnDocument : 'after', includeResultMetadata: true }, function(err, msg, blah) {
         if (err) return callback(err)
         if ( !msg.value ) {
             return callback(new Error("Queue.ping(): Unidentified ack  : " + ack))
@@ -215,7 +215,7 @@ Queue.prototype.ack = function(ack, callback) {
             deleted : now(),
         }
     }
-    self._ops.findOneAndUpdate3(query, update, { returnDocument : 'after' }, function(err, msg, blah) {
+    self._ops.findOneAndUpdate3(query, update, { returnDocument : 'after', includeResultMetadata: true }, function(err, msg, blah) {
         if (err) return callback(err)
         if ( !msg.value ) {
             return callback(new Error("Queue.ack(): Unidentified ack : " + ack))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "async": "^2.6.2",
         "mongodb4": "npm:mongodb@^4.4.1",
         "mongodb5": "npm:mongodb@^5.7.0",
+        "mongodb6": "npm:mongodb@^6.0.0",
         "tape": "^4.10.1"
       },
       "peerDependencies": {
@@ -649,7 +650,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
       "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1509,7 +1510,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1658,6 +1659,62 @@
         "node": ">=14.20.1"
       }
     },
+    "node_modules/mongodb6": {
+      "name": "mongodb",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
+      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
+      "dev": true,
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.0.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb6/node_modules/bson": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
+      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -1749,7 +1806,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -2424,7 +2481,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
       "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -3097,7 +3154,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "devOptional": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -3176,6 +3233,25 @@
         }
       }
     },
+    "mongodb6": {
+      "version": "npm:mongodb@6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
+      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
+      "dev": true,
+      "requires": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.0.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
+          "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
+          "dev": true
+        }
+      }
+    },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -3250,7 +3326,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "memory-pager": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-queue-up",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "types": "mongodb-queue.d.ts",
@@ -9,19 +9,21 @@
     "mongodb-queue.d.ts"
   ],
   "scripts": {
-    "test": "npm run test4 && npm run test5",
+    "test": "npm run test4 && npm run test5 && npm run test6",
     "test4": "set -e; for FILE in test/*.js; do echo --- $FILE - mongodb v4 ---; node $FILE 4; done",
-    "test5": "set -e; for FILE in test/*.js; do echo --- $FILE - mongodb v5 ---; node $FILE 5; done"
+    "test5": "set -e; for FILE in test/*.js; do echo --- $FILE - mongodb v5 ---; node $FILE 5; done",
+    "test6": "set -e; for FILE in test/*.js; do echo --- $FILE - mongodb v6 ---; node $FILE 6; done"
   },
   "dependencies": {},
   "devDependencies": {
     "async": "^2.6.2",
     "mongodb4": "npm:mongodb@^4.4.1",
     "mongodb5": "npm:mongodb@^5.7.0",
+    "mongodb6": "npm:mongodb@^6.0.0",
     "tape": "^4.10.1"
   },
   "peerDependencies": {
-    "mongodb": "^4 || ^5"
+    "mongodb": "^4 || ^5 || ^6"
   },
   "homepage": "https://github.com/mhassan1/mongodb-queue-up",
   "repository": {


### PR DESCRIPTION
This PR adds support for `mongodb@6`. This is not a breaking change; this library will work with `mongodb@4`, `mongodb@5`, and `mongodb@6`.