### PR TITLE
Added `listWaiting`, `listInFlight`, `incomplete`, and `listIncomplete` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,16 +370,77 @@ queue.size((err, count) => {
 })
 ```
 
+Use `listWaiting` to get the messages, themselves.
+
+### .listWaiting() ###
+
+Returns the list of messages that are waiting in the queue.
+
+```js
+queue.listWaiting((err, messages) => {
+    console.log('This queue has %d current messages', messages.length)
+})
+```
+
+The message structure will match `get`.
+
+Use `size` to just get the count.
+
 ### .inFlight() ###
 
-Returns the total number of messages that are currently in flight. ie. that
-have been received but not yet acked:
+Returns the total number of messages that are currently in flight, i.e. that
+have been retrieved, not yet acknowledged, but are being pinged:
 
 ```js
 queue.inFlight((err, count) => {
     console.log('A total of %d messages are currently being processed', count)
 })
 ```
+
+Use `listInFlight` to get the messages, themselves.
+
+### .listInFlight() ###
+
+Returns the list of messages that are currently in flight, i.e. that
+have been retrieved, not yet acknowledged, but are being pinged:
+
+```js
+queue.listInFlight((err, messages) => {
+    console.log('A total of %d messages are currently being processed', messages.length)
+})
+```
+
+The message structure will match `get`.
+
+Use `inFlight` to just get the count.
+
+### .incomplete() ###
+
+Returns the total number of messages that are currently incomplete, i.e. that
+have been retrieved, not yet acknowledged, but are NOT being pinged:
+
+```js
+queue.incomplete((err, count) => {
+    console.log('A total of %d messages are currently incomplete', count)
+})
+```
+
+Use `listIncomplete` to get the messages, themselves.
+
+### .listIncomplete() ###
+
+Returns the list of messages that are currently incomplete, i.e. that
+have been retrieved, not yet acknowledged, but are NOT being pinged:
+
+```js
+queue.listIncomplete((err, messages) => {
+    console.log('A total of %d messages are currently incomplete', messages.length)
+})
+```
+
+The message structure will match `get`.
+
+Use `incomplete` to just get the count.
 
 ### .done() ###
 
@@ -433,6 +494,10 @@ We may add the ability for each function to return a promise in the future so it
 async/await.
 
 ## Releases ##
+
+### 5.3.0 (2023-10-12) ###
+
+* [NEW] Added `listWaiting`, `listInFlight`, `incomplete`, and `listIncomplete` methods
 
 ### 5.2.0 (2023-09-11) ###
 

--- a/mongodb-queue.d.ts
+++ b/mongodb-queue.d.ts
@@ -19,7 +19,11 @@ declare namespace mongodbQueue {
     clean(callback: QueueCallback<any>): void;
     total(callback: QueueCallback<number>): void;
     size(callback: QueueCallback<number>): void;
+    listWaiting(callback: QueueCallback<QueueMessage[]>): void;
     inFlight(callback: QueueCallback<number>): void;
+    listInFlight(callback: QueueCallback<QueueMessage[]>): void;
+    incomplete(callback: QueueCallback<number>): void;
+    listIncomplete(callback: QueueCallback<QueueMessage[]>): void;
     done(callback: QueueCallback<number>): void;
   }
 

--- a/test/stats.js
+++ b/test/stats.js
@@ -44,6 +44,32 @@ setup(function(client, db) {
                     })
                 },
                 function(next) {
+                    queue.incomplete(function(err, count) {
+                        t.equal(count, 0, 'There are no incomplete messages')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listWaiting(function(err, messages) {
+                        t.equal(messages.length, 1, 'List of waiting in queue is one')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listInFlight(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no inFlight messages')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listIncomplete(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no incomplete messages')
+                        next()
+                    })
+                },
+                function(next) {
                     queue.done(function(err, count) {
                         t.equal(count, 0, 'There are no done messages')
                         next()
@@ -75,6 +101,34 @@ setup(function(client, db) {
                     })
                 },
                 function(next) {
+                    queue.incomplete(function(err, count) {
+                        t.equal(count, 1, 'There is one incomplete message')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listWaiting(function(err, messages) {
+                        t.equal(messages.length, 0, 'List of waiting in queue is now zero (ie. none to come)')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listInFlight(function(err, messages) {
+                        t.equal(messages.length, 1, 'There is one inflight message')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listIncomplete(function(err, messages) {
+                        t.equal(messages.length, 1, 'There is one incomplete message')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
+                        next()
+                    })
+                },
+                function(next) {
                     queue.done(function(err, count) {
                         t.equal(count, 0, 'There are still no done messages')
                         next()
@@ -102,6 +156,30 @@ setup(function(client, db) {
                 function(next) {
                     queue.inFlight(function(err, count) {
                         t.equal(count, 0, 'There are no inflight messages anymore')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.incomplete(function(err, count) {
+                        t.equal(count, 0, 'There are no incomplete messages anymore')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listWaiting(function(err, messages) {
+                        t.equal(messages.length, 0, 'List of waiting in queue is still zero (ie. none to come)')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listInFlight(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no inflight messages anymore')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listIncomplete(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no incomplete messages anymore')
                         next()
                     })
                 },
@@ -154,6 +232,32 @@ setup(function(client, db) {
                     })
                 },
                 function(next) {
+                    queue.incomplete(function(err, count) {
+                        t.equal(count, 0, 'There are no incomplete messages')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listWaiting(function(err, messages) {
+                        t.equal(messages.length, 1, 'List of waiting in queue is one')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listInFlight(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no inFlight messages')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listIncomplete(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no incomplete messages')
+                        next()
+                    })
+                },
+                function(next) {
                     queue.done(function(err, count) {
                         t.equal(count, 0, 'There are no done messages')
                         next()
@@ -181,6 +285,34 @@ setup(function(client, db) {
                 function(next) {
                     queue.inFlight(function(err, count) {
                         t.equal(count, 0, 'There are no inflight messages again')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.incomplete(function(err, count) {
+                        t.equal(count, 1, 'There is one incomplete message')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listWaiting(function(err, messages) {
+                        t.equal(messages.length, 1, 'List of waiting in queue is still at one')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listInFlight(function(err, messages) {
+                        t.equal(messages.length, 0, 'There are no inflight messages again')
+                        next()
+                    })
+                },
+                function(next) {
+                    queue.listIncomplete(function(err, messages) {
+                        t.equal(messages.length, 1, 'List of incomplete is at one')
+                        t.ok(messages[0].id, 'Got a msg.id (sanity check)')
+                        t.equal(messages[0].payload, 'Hello, World!', 'Got the right payload')
                         next()
                     })
                 },


### PR DESCRIPTION
This PR adds new methods:
* `listWaiting`: lists the messages that are waiting in the queue (same length as `size`)
* `listInFlight`: lists the messages that are in flight (same length as `inFlight`)
* `incomplete`: gets the count of messages that are incomplete (similar to `inFlight`, but without a filter on `visible`)
* `listIncomplete`: lists the messages that are incomplete (same length as `incomplete`)

Resolves https://github.com/mhassan1/mongodb-queue-up/issues/11.