### PR TITLE
Replaced `deleted:{$exists:true}` with `deleted:{$ne:null}` for better index usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ async/await.
 
 ## Releases ##
 
+### 5.4.0 (2023-10-12) ###
+
+* [NEW] Replaced `deleted:{$exists:true}` with `deleted:{$ne:null}` for better index usage
+
 ### 5.3.0 (2023-10-12) ###
 
 * [NEW] Added `listWaiting`, `listInFlight`, `incomplete`, and `listIncomplete` methods

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -235,7 +235,7 @@ Queue.prototype.clean = function(callback) {
     var self = this
 
     var query = {
-        deleted : { $exists : true },
+        deleted : { $ne : null },
     }
 
     self._ops.deleteMany1(query, callback)
@@ -349,7 +349,7 @@ Queue.prototype.done = function(callback) {
     var self = this
 
     var query = {
-        deleted : { $exists : true },
+        deleted : { $ne : null },
     }
 
     self._ops.countDocuments1(query, function(err, count) {


### PR DESCRIPTION
This PR replaces usage of `deleted:{$exists:true}` with `deleted:{$ne:null}` in the `clean` and `done` methods. This should result in better usage of the `{deleted:1,visible:1}` index, without any change in functionality.